### PR TITLE
Fix an issue with Python 3

### DIFF
--- a/requests_ftp/ftp.py
+++ b/requests_ftp/ftp.py
@@ -286,7 +286,7 @@ class FTPAdapter(BaseAdapter):
             path = path[1:]
 
         host = parsed.hostname
-        port = parsed.port
+        port = parsed.port or 0
 
         return (host, port, path)
 


### PR DESCRIPTION
The code in ftplib checks port > 0. This works with port = None in Python 2
because it allows such comparisons, but Python 3 is more strict. The solution
(I think) is to just use the default port, 0, in this case.

The README says to add tests, but I have no idea where. 
