### PR TITLE
Add tests and assorted fixes and improvements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/requests_ftp/ftp.py
+++ b/requests_ftp/ftp.py
@@ -137,6 +137,7 @@ class FTPAdapter(requests.adapters.BaseAdapter):
                            'STOR': self.stor,
                            'NLST': self.nlst,
                            'SIZE': self.size,
+                           'HEAD': self.size,
                            'GET': self.retr,}
 
     def send(self, request, **kwargs):

--- a/requests_ftp/ftp.py
+++ b/requests_ftp/ftp.py
@@ -81,6 +81,11 @@ def data_callback_factory(variable):
     variable should be a file-like structure.'''
     def callback(data):
         variable.write(data)
+        if hasattr(variable, "content_len"):
+            variable.content_len += len(data)
+        else:
+            variable.content_len = len(data)
+
         return
 
     return callback
@@ -108,6 +113,8 @@ def build_response(request, data, code, encoding):
     response.url = request.url
     response.request = request
     response.status_code = int(code.split()[0])
+    if hasattr(data, "content_len"):
+        response.headers['Content-Length'] = str(data.content_len)
 
     # Make sure to seek the file-like raw object back to the start.
     response.raw.seek(0)
@@ -247,6 +254,7 @@ class FTPAdapter(requests.adapters.BaseAdapter):
         # method to the release_conn() method. This is a dirty hack, but there
         # you go.
         data.release_conn = data.close
+        data.content_len = size
 
         response = build_text_response(request, data, '213')
 

--- a/requests_ftp/ftp.py
+++ b/requests_ftp/ftp.py
@@ -137,8 +137,8 @@ class FTPAdapter(requests.adapters.BaseAdapter):
                            'STOR': self.stor,
                            'NLST': self.nlst,
                            'SIZE': self.size,
-                           'HEAD': self.size,
-                           'GET': self.retr,}
+                           'HEAD': self.head,
+                           'GET': self.get,}
 
     def send(self, request, **kwargs):
         '''Sends a PreparedRequest object over FTP. Returns a response object.
@@ -240,6 +240,20 @@ class FTPAdapter(requests.adapters.BaseAdapter):
 
         return response
 
+    def get(self, path, request):
+        '''Executes the FTP RETR command on the given path.
+
+           This is the same as retr except that the FTP server code is
+           converted to a HTTP 200.
+        '''
+
+        response = self.retr(path, request)
+
+        # Errors are handled in send(), so assume everything is ok if we
+        # made it this far
+        response.status_code = codes.ok
+        return response
+
     def size(self, path, request):
         '''Executes the FTP SIZE command on the given path.'''
         self.conn.voidcmd('TYPE I')  # SIZE is not usually allowed in ASCII mode
@@ -261,6 +275,17 @@ class FTPAdapter(requests.adapters.BaseAdapter):
 
         self.conn.close()
 
+        return response
+
+    def head(self, path, request):
+        '''Executes the FTP SIZE command on the given path.
+
+           This is the same as size except that the FTP server code is
+           converted to a HTTP 200.
+        '''
+
+        response = self.size(path, request)
+        response.status_code = codes.ok
         return response
 
     def stor(self, path, request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import threading
 import requests
 import requests_ftp
 from simple_ftpd import SimpleFTPServer
+from simple_proxy import ProxyServer
 
 def pytest_configure(config):
     requests_ftp.monkeypatch_session()
@@ -19,4 +20,13 @@ def ftpd():
 @pytest.fixture
 def session():
     return requests.Session()
+
+@pytest.fixture(scope='session')
+def proxy():
+    proxy_server = ProxyServer()
+    proxy_server_thread = threading.Thread(target=proxy_server.serve_forever)
+    proxy_server_thread.daemon = True
+    proxy_server_thread.start()
+
+    return proxy_server
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+import threading
+import requests
+import requests_ftp
+from simple_ftpd import SimpleFTPServer
+
+def pytest_configure(config):
+    requests_ftp.monkeypatch_session()
+
+@pytest.fixture(scope='session')
+def ftpd():
+    ftp_server = SimpleFTPServer()
+    ftp_server_thread = threading.Thread(target=ftp_server.serve_forever)
+    ftp_server_thread.daemon = True
+    ftp_server_thread.start()
+
+    return ftp_server
+
+@pytest.fixture
+def session():
+    return requests.Session()
+

--- a/tests/simple_ftpd.py
+++ b/tests/simple_ftpd.py
@@ -1,0 +1,56 @@
+from pyftpdlib.authorizers import DummyAuthorizer
+from pyftpdlib.handlers import FTPHandler
+from pyftpdlib.servers import FTPServer
+
+import socket
+import tempfile
+import shutil
+import threading
+
+class SimpleFTPServer(FTPServer):
+    """Starts a simple FTP server on a random free port. """
+
+    ftp_user = property(lambda s: 'fakeusername',
+            doc='User name added for authenticated connections')
+    ftp_password = property(lambda s: 'qweqwe', doc='Password for ftp_user')
+
+    # Set in __init__
+    anon_root = property(lambda s: s._anon_root, doc='Home directory for the anonymous user')
+    ftp_home = property(lambda s: s._ftp_home, doc='Home directory for ftp_user')
+    ftp_port = property(lambda s: s._ftp_port, doc='TCP port that the server is listening on')
+
+    def __init__(self):
+        # Create temp directories for the anonymous and authenticated roots
+        self._anon_root = tempfile.mkdtemp()
+        self._ftp_home = tempfile.mkdtemp()
+
+        authorizer = DummyAuthorizer()
+        authorizer.add_user(self.ftp_user, self.ftp_password, self.ftp_home, perm='elradfmwM')
+        authorizer.add_anonymous(self.anon_root)
+
+        handler = FTPHandler
+        handler.authorizer = authorizer
+
+        # Create a socket on any free port
+        self._ftp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._ftp_socket.bind(('', 0))
+        self._ftp_port = self._ftp_socket.getsockname()[1]
+
+        # Create a new pyftpdlib server with the socket and handler we've configured
+        FTPServer.__init__(self, self._ftp_socket, handler)
+
+    def __del__(self):
+        self.close_all()
+
+        if hasattr(self, '_anon_root'):
+            shutil.rmtree(self._anon_root, ignore_errors=True)
+
+        if hasattr(self, '_ftp_home'):
+            shutil.rmtree(self._ftp_home, ignore_errors=True)
+
+if __name__ == "__main__":
+    server = SimpleFTPServer()
+    print("FTPD running on port %d" % server.ftp_port)
+    print("Anonymous root: %s" % server.anon_root)
+    print("Authenticated root: %s" % server.ftp_home)
+    server.serve_forever()

--- a/tests/simple_proxy.py
+++ b/tests/simple_proxy.py
@@ -1,0 +1,43 @@
+from six.moves import SimpleHTTPServer, socketserver
+from six.moves.urllib.request import urlopen
+
+class ProxyHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    """ Proxy handler that calls a user-provided function and
+        forwards the request via urllib.
+
+    """
+    def do_GET(self):
+        self.server.requests.add(self.path)
+        data = urlopen(self.path).read()
+        self.send_response(200)
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+class ProxyServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+    port = property(lambda s: s._port, doc="TCP port the server is running on")
+
+    def __init__(self):
+        """ HTTP proxy server
+
+            Can act as a proxy for whatever kinds of URLs urllib can handle.
+            Stores requested paths in the set self.requests.
+
+            :param cb: A user-provided method called for each proxy request. The
+                       method should take an argument containing the proxied
+                       request. The return value will be ignored.
+        """
+
+        self.requests = set()
+
+        # Create and bind a new TCPServer on any free port
+        socketserver.TCPServer.__init__(self, ('', 0), ProxyHandler)
+        self._port = self.socket.getsockname()[1]
+
+if __name__ == "__main__":
+    def cb(path): print("Proxied request for %s" % path)
+    proxy = ProxyServer(cb)
+    print("Proxy running on port %d" % proxy.port)
+    proxy.serve_forever()

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -1,0 +1,155 @@
+import threading
+import os
+import contextlib
+import tempfile
+
+import requests
+import requests_ftp
+
+from threadmgr import socketServer
+
+import pytest
+
+@contextlib.contextmanager
+def _prepareTestData(dir):
+    """ Writes data to the given directory and returns a tuple of (tempname, testdata) """
+    with tempfile.NamedTemporaryFile(dir=dir) as f:
+        # Write ourself to the directory
+        with open(__file__, "rb") as testinput:
+            testdata = testinput.read()
+        f.write(testdata)
+        f.flush()
+
+        yield (os.path.basename(f.name), testdata)
+
+def test_basic_get(ftpd, session):
+    # Create a file in the anonymous root and fetch it
+    with _prepareTestData(ftpd.anon_root) as (testfile, testdata):
+        response = session.get('ftp://127.0.0.1:%d/%s' % (ftpd.ftp_port, testfile))
+
+        assert response.status_code == requests.codes.ok
+
+        # Check the length
+        assert response.headers['Content-Length'] == str(len(testdata))
+
+        # Check the contents
+        assert response.content == testdata
+
+def test_missing_get(ftpd, session):
+    # Fetch a file that does not exist, look for a 404
+    response = session.get("ftp://127.0.0.1:%d/no/such/path" % ftpd.ftp_port)
+    assert response.status_code == requests.codes.not_found
+
+def test_authenticated_get(ftpd, session):
+    # Create a file in the testuser's root and fetch it
+    with _prepareTestData(dir=ftpd.ftp_home) as (testfile, testdata):
+        response = session.get('ftp://127.0.0.1:%d/%s' % (ftpd.ftp_port, testfile),
+                auth=(ftpd.ftp_user, ftpd.ftp_password))
+
+        assert response.status_code == requests.codes.ok
+        assert response.headers['Content-Length'] == str(len(testdata))
+
+        # Check the contents
+        assert response.content == testdata
+
+def test_head(ftpd, session):
+    # Perform a HEAD over an anonymous connection
+    with _prepareTestData(dir=ftpd.anon_root) as (testfile, testdata):
+        response = session.head('ftp://127.0.0.1:%d/%s' % (ftpd.ftp_port, testfile))
+
+        assert response.status_code == requests.codes.ok
+        assert response.headers['Content-Length'] == str(len(testdata))
+
+def test_connection_refused(session):
+    # Create and bind a socket but do not listen to ensure we have a port
+    # that will refuse connections
+    def target(s):
+        pass
+
+    with socketServer(target) as port:
+        with pytest.raises(requests.exceptions.ConnectionError):
+            session.get('ftp://127.0.0.1:%d/' % port)
+
+def test_connection_timeout(session):
+    # Create, bind, and listen on a socket, but never accept
+    def target(s):
+        s.listen(0)
+
+    with socketServer(target) as port:
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            session.get('ftp://127.0.0.1:%d/' % port, timeout=1)
+
+def test_login_timeout(session):
+    # Create and accept a socket, but stop responding after sending
+    # the welcome
+    def target(s, event):
+        s.listen(0)
+        (clientsock, _addr) = s.accept()
+        try:
+            clientsock.send(b'220 welcome\r\n')
+            # Wait for the exception to be raised in the client
+            event.wait(5)
+        finally:
+            clientsock.close()
+
+    event = threading.Event()
+    with socketServer(target, event) as port:
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            session.get('ftp://127.0.0.1:%d/' % port, timeout=1)
+
+def test_connection_close(session):
+    # Create and accept a socket, then close it after the welcome
+    def target(s):
+        s.listen(0)
+        (clientsock, _addr) = s.accept()
+        try:
+            clientsock.send(b'220 welcome\r\n')
+        finally:
+            clientsock.close()
+
+    with socketServer(target) as port:
+        with pytest.raises(requests.exceptions.ConnectionError):
+            session.get('ftp://127.0.0.1:%d/' % port)
+
+def test_invalid_response(session):
+    # Send an invalid welcome
+    def target(s):
+        s.listen(0)
+        (clientsock, _addr) = s.accept()
+        try:
+            clientsock.send(b'no code\r\n')
+        finally:
+            clientsock.close()
+
+    with socketServer(target) as port:
+        with pytest.raises(requests.exceptions.RequestException):
+            session.get('ftp://127.0.0.1:%d/' % port)
+
+def test_invalid_code(session):
+    # Send a welcome, then reply with something weird to the USER command
+    def target(s):
+        s.listen(0)
+        (clientsock, _addr) = s.accept()
+        try:
+            clientsock.send(b'220 welcome\r\n')
+            clientsock.recv(1024)
+            clientsock.send(b'125 this makes no sense\r\n')
+        finally:
+            clientsock.close()
+
+    with socketServer(target) as port:
+        with pytest.raises(requests.exceptions.RequestException):
+            session.get('ftp://127.0.0.1:%d/' % port)
+
+def test_unavailable(session):
+    def target(s):
+        s.listen(0)
+        (clientsock, _addr) = s.accept()
+        try:
+            clientsock.send(b'421 go away\r\n')
+        finally:
+            clientsock.close()
+
+    with socketServer(target) as port:
+        response = session.get('ftp://127.0.0.1:%d/' % port)
+        assert response.status_code == requests.codes.unavailable

--- a/tests/test_ftp_proxy.py
+++ b/tests/test_ftp_proxy.py
@@ -1,0 +1,83 @@
+# Requesting an FTP resource through a proxy will actually create a request
+# to a HTTP proxy, and the proxy server will handle the FTP parts. This is
+# considered OK for some reason.
+
+import pytest
+
+import threading
+import contextlib
+import tempfile
+import os
+
+import requests
+import requests_ftp
+
+from threadmgr import socketServer
+
+@contextlib.contextmanager
+def _prepareTestData(dir):
+    """ Writes data to the given directory and returns a tuple of (tempname, testdata) """
+    with tempfile.NamedTemporaryFile(dir=dir) as f:
+        # Write ourself the directory
+        with open(__file__, "rb") as testinput:
+            testdata = testinput.read()
+        f.write(testdata)
+        f.flush()
+
+        yield (os.path.basename(f.name), testdata)
+
+def test_proxy_get(ftpd, proxy, session):
+    # Create a file in the anonymous root and fetch it through a proxy
+    with _prepareTestData(ftpd.anon_root) as (testfile, testdata):
+        testurl = 'ftp://127.0.0.1:%d/%s' % (ftpd.ftp_port, testfile)
+        response = session.get(testurl, proxies={'ftp': 'localhost:%d' % proxy.port})
+
+        assert response.status_code == requests.codes.ok
+
+        # Check the length
+        assert response.headers['Content-Length'] == str(len(testdata))
+
+        # Check the contents
+        assert response.content == testdata
+
+        # Check that it went through the proxy
+        assert testurl in proxy.requests
+
+def test_proxy_connection_refused(ftpd, session):
+    # Create and bind a socket but do not listen to ensure we have a port
+    # that will refuse connections
+    def target(s):
+        pass
+
+    with socketServer(target) as port:
+        with pytest.raises(requests.exceptions.ConnectionError):
+            session.get('ftp://127.0.0.1:%d/' % ftpd.ftp_port,
+                    proxies={'ftp': 'localhost:%d' % port})
+
+def test_proxy_read_timeout(ftpd, session):
+    # Create and accept a socket, but never respond
+    def target(s, event):
+        s.listen(0)
+        (clientsock, _addr) = s.accept()
+        try:
+            event.wait(5)
+        finally:
+            clientsock.close()
+
+    event = threading.Event()
+    with socketServer(target, event) as port:
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            session.get('ftp://127.0.0.1:%d' % ftpd.ftp_port,
+                    proxies={'ftp': 'localhost:%d' % port}, timeout=1)
+
+def test_proxy_connection_close(ftpd, session):
+    # Create and accept a socket, then close it
+    def target(s):
+        s.listen(0)
+        (clientsock, _addr) = s.accept()
+        clientsock.close()
+
+    with socketServer(target) as port:
+        with pytest.raises(requests.exceptions.ConnectionError):
+            session.get('ftp://127.0.0.1:%d/' % ftpd.ftp_port,
+                    proxies={'ftp': 'localhost:%d' % port}, timeout=1)

--- a/tests/threadmgr.py
+++ b/tests/threadmgr.py
@@ -1,0 +1,59 @@
+import threading
+import contextlib
+import socket
+import sys
+import six
+
+class TestThread(threading.Thread):
+    """ A Thread class that save exceptions raised by the thread. """
+
+    def __init__(self, exnlist, *args, **kwargs):
+        self._exnlist = exnlist
+        super(TestThread, self).__init__(*args, **kwargs)
+
+    def run(self, *args, **kwargs):
+        try:
+            super(TestThread, self).run(*args, **kwargs)
+        except:
+            self._exnlist.append(sys.exc_info())
+
+@contextlib.contextmanager
+def socketServer(target, event=None):
+    """ Starts a server, running target in a new thread.
+
+        Target is the thread target, and will receive the server socket
+        and an optional Event as arguments. If event is not None, it
+        will be passed as the second argument to target and will be
+        set during the __exit__ phase.
+
+        Returns the TCP port the server is running on.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    try:
+        s.bind(('', 0))
+        port = s.getsockname()[1]
+
+        if event:
+            args = (s, event)
+        else:
+            args = (s,)
+
+        exn_list = []
+        server_thread = TestThread(exn_list, target=target, args=args)
+        server_thread.daemon = True
+        server_thread.start()
+
+        yield port
+
+        if event:
+            event.set()
+
+        server_thread.join(1)
+
+        # Check for and re-raise exceptions
+        if exn_list:
+            exc_info = exn_list[0]
+            six.reraise(*exc_info)
+    finally:
+        s.close()


### PR DESCRIPTION
These patches, in brief, do the following:

- Add a test suite (RETR and SIZE only, I didn't do anything with STOR or other commands)
- Some changes to make the FTP adapter behave more like the HTTP-based adapters, so a ftp-ized requests Session can switch between http and ftp URLs more transparently
- Add proxy support, because that's a thing somehow? If you do curl --proxy *proxy* ftp://... it'll do it as an http request, so this change just passes the request to HTTPAdapter
- miscellaneous minor bug fixes