### PR TITLE
Adding 2 tests and updated statud_code build (solve Issue #10)

### DIFF
--- a/requests_ftp/ftp.py
+++ b/requests_ftp/ftp.py
@@ -9,6 +9,7 @@ from io import BytesIO
 import cgi
 import os
 import socket
+import logging
 
 from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout
 from requests.exceptions import RequestException
@@ -102,6 +103,35 @@ def build_binary_response(request, data, code):
     return build_response(request, data, code, None)
 
 
+def get_status_code_from_code_response(code):
+    '''
+    The idea is to handle complicated code response (even multi lines).
+    We get the status code in two ways:
+    - extracting the code from the last valid line in the response
+    - getting it from the 3first digits in the code
+    After a comparaison between the two values,
+    we can safely set the code or raise a warning.
+
+    Examples:
+        - get_code('200 Welcome') == 200
+
+        - multi_line_code = '226-File successfully transferred\n226 0.000 seconds'
+          get_code(multi_line_code) == 226
+
+        - multi_line_with_code_conflits = '200-File successfully transferred\n226 0.000 seconds'
+          get_code(multi_line_with_code_conflits) == 226
+    '''
+    last_valid_line_from_code = [line for line in code.split('\n') if line][-1]
+    status_code_from_last_line = int(last_valid_line_from_code.split()[0])
+    status_code_from_first_digits = int(code[:3])
+    if status_code_from_last_line != status_code_from_first_digits:
+        logging.warning(
+            'Status code seems to be non consistant.\n'
+            'Code received: %d, extracted: %d and %d' % (
+                code, status_code_from_last_line, status_code_from_first_digits))
+    return status_code_from_last_line
+
+
 def build_response(request, data, code, encoding):
     '''Builds a response object from the data returned by ftplib, using the
     specified encoding.'''
@@ -113,8 +143,8 @@ def build_response(request, data, code, encoding):
     response.raw = data
     response.url = request.url
     response.request = request
-    last_valid_line_from_code = [line for line in code.split('\n') if line][-1]
-    response.status_code = int(last_valid_line_from_code.split()[0])
+    response.status_code = get_status_code_from_code_response(code)
+
     if hasattr(data, "content_len"):
         response.headers['Content-Length'] = str(data.content_len)
 

--- a/requests_ftp/ftp.py
+++ b/requests_ftp/ftp.py
@@ -99,7 +99,7 @@ def build_text_response(request, data, code):
 
 def build_binary_response(request, data, code):
     '''Build a response for data whose encoding is unknown.'''
-    return build_response(request, data, code,  None)
+    return build_response(request, data, code, None)
 
 
 def build_response(request, data, code, encoding):
@@ -113,7 +113,8 @@ def build_response(request, data, code, encoding):
     response.raw = data
     response.url = request.url
     response.request = request
-    response.status_code = int(code.split()[0])
+    last_valid_line_from_code = [line for line in code.split('\n') if line][-1]
+    response.status_code = int(last_valid_line_from_code.split()[0])
     if hasattr(data, "content_len"):
         response.headers['Content-Length'] = str(data.content_len)
 

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -57,6 +57,29 @@ def test_authenticated_get(ftpd, session):
         assert response.content == testdata
 
 
+def test_basic_retr(ftpd, session):
+    # Fetch a file with the retr command
+    with _prepareTestData(dir=ftpd.anon_root) as (testfile, testdata):
+        response = session.retr("ftp://127.0.0.1:%d/%s" % (ftpd.ftp_port, testfile))
+
+        assert response.status_code == 226
+
+
+def test_ftp_retr_with_multiple_lines_response(ftpd, session):
+    '''
+    Example from NASA:
+        ftp://lasco6.nascom.nasa.gov/pub/lasco/lastimage/lastimg_C2.gif
+    The code received is:
+        '226-File successfully transferred\n226 0.000 seconds'
+    `status_code` need to be build from here and get the code
+    from the latest line
+    '''
+    with _prepareTestData(dir=ftpd.anon_root) as (testfile, testdata):
+        response = session.retr("ftp://127.0.0.1:%d/%s" % (ftpd.ftp_port, testfile))
+
+        assert response.status_code == 226
+
+
 def test_head(ftpd, session):
     # Perform a HEAD over an anonymous connection
     with _prepareTestData(dir=ftpd.anon_root) as (testfile, testdata):


### PR DESCRIPTION
/!\ This PR Is incomplete, need help and improvements /!\

Well, note sure it solves completly the problem of #10. The fact is; as a ftp response code, we can return multi line code like so:

    226-This is the first line of the response
     226 This line does not end the response; note the leading space
    226 This is the last line of the response, using code 226

(source: http://cr.yp.to/ftp/request.html)

As far as I know, we should consider the last line, and the status code we're looking for should be the 3 first digit followed by a space. (it's more or less the code I added)
Another approach would be to take code[:3] instead of the first element after a `split()`.
Anyway, my suggestion can be found in `ftp.py`.

I added one test for `sesison.retr()` asserting (`status_code == 226`), and another test called `test_ftp_retr_with_multiple_lines_response`. (The latter need to be completly rewritten, it does nothnig interesting right now and is misleading)
I described in it a real life example of an Url with such a problem (returning a multi line code starting with 226-File...).
I wasn't able to reproduce it with the current setup. I'm not really sure how to setup a custom code from the ftpServer used in the tests. I'm quite new to that, sorry.

Hope we can build something from here. Cheers.