### PR TITLE
expose FTPSession

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Here's how you use it:
 .. code-block:: pycon
 
     >>> import requests_ftp
-    >>> s = requests.FTPSession()
+    >>> s = requests_ftp.FTPSession()
     >>> resp = s.list('ftp://127.0.0.1/', auth=('Lukasa', 'notmypass'))
     >>> resp.status_code
     '226'
@@ -59,7 +59,7 @@ approach:
 
     >>> import requests_ftp
     >>> import some_library
-    >>> s = requests.FTPSession()
+    >>> s = requests_ftp.FTPSession()
     >>> resp = some_library.get('ftp://127.0.0.1/', auth=('Lukasa', 'notmypass'), session=s)
 
 If they do not, either modify the library to add a session parameter, or as an absolute

--- a/requests_ftp/__init__.py
+++ b/requests_ftp/__init__.py
@@ -18,4 +18,4 @@ __author__ = 'Cory Benfield'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2012 Cory Benfield'
 
-from .ftp import FTPAdapter, monkeypatch_session
+from .ftp import FTPAdapter, FTPSession, monkeypatch_session


### PR DESCRIPTION
I am trying to get into using this library. But if I am not mistaken, two of the examples in the README are wrong: When not monkey-patching, the `FTPSession` class must be imported either from `requests_ftp.ftp.FTPSession` or - after this PR is merged - from `requests_ftp`.

Also, I think the quality declarations are a bit too scary. This implementation might not be perfect, but still useful. And there *are* already some tests. Some code coverage would help. I can perhaps address this in another PR...